### PR TITLE
Save GA data from query string to cookie, add it dynamically to checkout...

### DIFF
--- a/checkout/checkout.js
+++ b/checkout/checkout.js
@@ -1,0 +1,38 @@
+var cookie = require('cookie');
+var Delegate = require('dom-delegate');
+var qs = require('querystring');
+var _ = require('underscore');
+
+function linkify(scope) {
+  saveGADataToCookie();
+  addGADataToLinks(scope);
+}
+
+function saveGADataToCookie() {
+  if (window.location.href.indexOf('?') === -1) return;
+
+  var query = qs.parse(window.location.href.split('?').pop().split('#')[0]);
+  query = _.pick(query, function(v, k) {return v && k.indexOf('utm_') === 0});
+  query = qs.stringify(query);
+
+  if (query) document.cookie = cookie.serialize('ga_data', query);
+};
+
+function addGADataToLinks(scope) {
+  var query = cookie.parse(document.cookie).ga_data;
+  if (!query) return;
+
+  var delegate = new Delegate(scope || document.body);
+
+  delegate.on('click', 'a', function (event) {
+    var url = event.target.getAttribute('href');
+    if (!url.match('checkout')) return;
+
+    event.preventDefault();
+    window.location.href = url + (url.indexOf('?') === -1 ? '?' : '&') + query;
+  });
+};
+
+module.exports = {
+  linkify: linkify
+};

--- a/checkout/package.json
+++ b/checkout/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "checkout.js"
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "test-server": "./node_modules/.bin/gulp test-server"
   },
   "dependencies": {
-    "solidus-client": "^1.2.2"
+    "cookie": "^0.1.2",
+    "dom-delegate": "^2.0.3",
+    "qs": "^2.4.1",
+    "solidus-client": "^1.2.2",
+    "underscore": "~1.7.0"
   },
   "devDependencies": {
     "handlebars": "~2.0.0",
@@ -36,7 +40,6 @@
     "gulp-rename": "~1.2.0",
     "run-sequence": "~1.0.1",
     "browserstacktunnel-wrapper": "~1.3.1",
-    "browserstack-webdriver": "~2.41.1",
-    "underscore": "~1.7.0"
+    "browserstack-webdriver": "~2.41.1"
   }
 }


### PR DESCRIPTION
... links

https://trello.com/c/ujzntj3o/864-funimact-conversion-tracking

The `checkout.linkify` function saves the GA data from the query string into a cookie. That cookie is later used to add back the GA data to the checkout links. They are then used by https://github.com/SparkartGroupInc/sparkart-services/pull/693.